### PR TITLE
Ensure all rows have uniform number of columns

### DIFF
--- a/pyexcel_text/__init__.py
+++ b/pyexcel_text/__init__.py
@@ -8,6 +8,7 @@
     :license: GPL v3
 """
 from pyexcel.presentation import STRINGIFICATION
+from pyexcel.sheets.matrix import uniform, Matrix
 from pyexcel_io import BookWriter, SheetWriterBase, is_string, WRITERS
 from pyexcel.deprecated import deprecated
 from functools import partial
@@ -112,6 +113,10 @@ class TextSheetWriter(SheetWriterBase):
         import tabulate
         if 'single_sheet_in_book' in self.keywords:
             self.keywords.pop('single_sheet_in_book')
+        if not isinstance(table, Matrix):
+            if not isinstance(table, list):
+                table = list(table)
+            width, table = uniform(table)
         self.filehandle.write(tabulate.tabulate(table,
                                                 tablefmt=self.file_type,
                                                 **self.keywords))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -13,6 +13,7 @@ else:
 class TestIO:
     def setUp(self):
         self.testfile = "testfile.simple"
+        self.testfile2 = None
         text.TABLEFMT = "simple"
     def test_normal_usage(self):
         content = [
@@ -53,9 +54,54 @@ class TestIO:
             -  ---  ---""").strip('\n')
         assert written_content.strip('\n') == content
 
+    def test_new_normal_usage_irregular_columns(self):
+        content = [
+            [1, 2, 3],
+            [4, 588, 6],
+            [7, 8]
+        ]
+        pe.save_as(array=content, dest_file_name=self.testfile)
+        f = open(self.testfile, "r")
+        written_content = f.read()
+        f.close()
+        content = dedent("""
+            Sheet Name: pyexcel_sheet1
+            -  ---  -
+            1    2  3
+            4  588  6
+            7    8
+            -  ---  -""").strip('\n')
+        print(written_content)
+        assert written_content.strip('\n') == content
+
+    def test_csvbook_irregular_columns(self):
+        content = [
+            [1, 2, 3],
+            [4, 588, 6],
+            [7, 8]
+        ]
+        self.testfile2 = "testfile.csv"
+        pe.save_as(array=content, dest_file_name=self.testfile2)
+        pe.save_as(file_name=self.testfile2, dest_file_name=self.testfile)
+
+        f = open(self.testfile, "r")
+        written_content = f.read()
+        f.close()
+
+        content = dedent("""
+            Sheet Name: testfile.csv
+            -  ---  -
+            1    2  3
+            4  588  6
+            7    8
+            -  ---  -""").strip('\n')
+        assert written_content.strip('\n') == content
+
     def tearDown(self):
         if os.path.exists(self.testfile):
             os.unlink(self.testfile)
+        if self.testfile2 and os.path.exists(self.testfile2):
+            os.unlink(self.testfile2)
 
 class TestRst:
     def setUp(self):


### PR DESCRIPTION
tabulate determines the number of columns to present based on
the row with the least number of columns.
See https://bitbucket.org/astanin/python-tabulate/issues/85

To workaround this, the data given to tabulate must have
uniform number of columns.

Fixes #6.
