### PR TITLE
Reuse unit test methods for multiple formats

### DIFF
--- a/pyexcel_text/__init__.py
+++ b/pyexcel_text/__init__.py
@@ -173,7 +173,7 @@ class JsonSheetWriter(TextSheetWriter):
 
     def write_array(self, table):
         import json
-        self.filehandle.write(json.dumps(table))
+        self.filehandle.write(json.dumps(table, sort_keys=True))
 
     def close(self):
         pass

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import unittest
 
 from textwrap import dedent
 import pyexcel as pe
@@ -10,11 +11,55 @@ if sys.version_info[0] < 3:
 else:
     from io import StringIO
 
-class TestIO:
+# Python 2.6 does not have unittest.expectedFailure; just ignore those test
+if hasattr(unittest, 'expectedFailure'):
+    expectedFailure = unittest.expectedFailure
+else:
+    expectedFailure = lambda func: lambda x: 'skip'
+
+class TestIO(unittest.TestCase):
+
+    TABLEFMT = 'simple'
+    expected_results = {
+        'dict': dedent("""
+            Sheet Name: sheet 1
+            -  -
+            1  2
+            3  4
+            -  -
+            Sheet Name: sheet 2
+            -  -
+            5  6
+            7  8
+            -  -""").strip('\n'),
+    }
+
     def setUp(self):
-        self.testfile = "testfile.simple"
+        text.TABLEFMT = self.TABLEFMT
+        self.testfile = 'testfile.%s' % self.TABLEFMT
         self.testfile2 = None
-        text.TABLEFMT = "simple"
+
+    def _check_test_file(self, name):
+        with open(self.testfile, "r") as f:
+            written_content = f.read()
+
+        written_content = written_content.strip('\n')
+
+        self.assertTrue(name in self.expected_results)
+
+        expected = self.expected_results[name]
+
+        self.assertEqual(written_content, expected)
+
+    def test_dict(self):
+        adict = {
+            'sheet 1': [[1,2],[3,4]],
+            'sheet 2': [[5,6],[7,8]]
+        }
+        pe.save_book_as(bookdict=adict, dest_file_name=self.testfile)
+
+        self._check_test_file('dict')
+
     def test_normal_usage(self):
         content = [
             [1, 2, 3],
@@ -23,17 +68,16 @@ class TestIO:
         ]
         s = pe.Sheet(content)
         text.save_as(s, self.testfile)
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
-        content = dedent("""
+
+        self._check_test_file('normal_usage')
+
+    expected_results['normal_usage'] = dedent("""
             Sheet Name: pyexcel
             -  ---  ---
             1    2    3
             4  588    6
             7    8  999
             -  ---  ---""").strip('\n')
-        assert written_content == content
 
     def test_new_normal_usage(self):
         content = [
@@ -42,17 +86,16 @@ class TestIO:
             [7, 8, 999]
         ]
         pe.save_as(array=content, dest_file_name=self.testfile)
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
-        content = dedent("""
+
+        self._check_test_file('new_normal_usage')
+
+    expected_results['new_normal_usage'] = dedent("""
             Sheet Name: pyexcel_sheet1
             -  ---  ---
             1    2    3
             4  588    6
             7    8  999
             -  ---  ---""").strip('\n')
-        assert written_content.strip('\n') == content
 
     def test_new_normal_usage_irregular_columns(self):
         content = [
@@ -61,17 +104,16 @@ class TestIO:
             [7, 8]
         ]
         pe.save_as(array=content, dest_file_name=self.testfile)
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
-        content = dedent("""
+
+        self._check_test_file('new_normal_usage_irregular_columns')
+
+    expected_results['new_normal_usage_irregular_columns'] = dedent("""
             Sheet Name: pyexcel_sheet1
             -  ---  -
             1    2  3
             4  588  6
             7    8
             -  ---  -""").strip('\n')
-        assert written_content.strip('\n') == content
 
     def test_csvbook_irregular_columns(self):
         content = [
@@ -83,18 +125,15 @@ class TestIO:
         pe.save_as(array=content, dest_file_name=self.testfile2)
         pe.save_as(file_name=self.testfile2, dest_file_name=self.testfile)
 
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
+        self._check_test_file('csvbook_irregular_columns')
 
-        content = dedent("""
+    expected_results['csvbook_irregular_columns'] = dedent("""
             Sheet Name: testfile.csv
             -  ---  -
             1    2  3
             4  588  6
             7    8
             -  ---  -""").strip('\n')
-        assert written_content.strip('\n') == content
 
     def test_column_series(self):
         content = [
@@ -106,19 +145,16 @@ class TestIO:
         s = pe.Sheet(content, name_columns_by_row=0)
 
         pe.save_as(array=s, dest_file_name=self.testfile)
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
 
-        content = dedent("""
+        self._check_test_file('column_series')
+
+    expected_results['column_series'] = dedent("""
             Sheet Name: pyexcel_sheet1
               Column 1    Column 2    Column 3
             ----------  ----------  ----------
                      1           2           3
                      4           5           6
                      7           8           9""").strip('\n')
-
-        assert written_content.strip('\n') == content
 
     def test_column_series_irregular_columns(self):
         content = [
@@ -130,20 +166,17 @@ class TestIO:
         s = pe.Sheet(content, name_columns_by_row=0)
 
         pe.save_as(array=s, dest_file_name=self.testfile)
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
+
+        self._check_test_file('column_series_irregular_columns')
 
         # FIXME: numerical align lost when one cell is missing
-        content = dedent("""
+    expected_results['column_series_irregular_columns'] = dedent("""
             Sheet Name: pyexcel_sheet1
               Column 1    Column 2  Column 3
             ----------  ----------  ----------
                      1           2  3
                      4           5  6
                      7           8""").strip('\n')
-
-        assert written_content.strip('\n') == content
 
     def test_data_frame(self):
         content = [
@@ -155,19 +188,16 @@ class TestIO:
         s = pe.Sheet(content, name_rows_by_column=0, name_columns_by_row=0)
 
         pe.save_as(array=s, dest_file_name=self.testfile)
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
 
-        content = dedent("""
+        self._check_test_file('data_frame')
+
+    expected_results['data_frame'] = dedent("""
             Sheet Name: pyexcel_sheet1
                      Column 1    Column 2    Column 3
             -----  ----------  ----------  ----------
             Row 1           1           2           3
             Row 2           4           5           6
             Row 3           7           8           9""").strip('\n')
-
-        assert written_content.strip('\n') == content
 
     def test_row_series(self):
         content = [
@@ -178,11 +208,10 @@ class TestIO:
         s = pe.Sheet(content, name_rows_by_column=0)
 
         pe.save_as(array=s, dest_file_name=self.testfile)
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
 
-        content = dedent("""
+        self._check_test_file('row_series')
+
+    expected_results['row_series'] = dedent("""
             Sheet Name: pyexcel_sheet1
             -----  -  -  -
             Row 1  1  2  3
@@ -190,47 +219,84 @@ class TestIO:
             Row 3  7  8  9
             -----  -  -  -""").strip('\n')
 
-        assert written_content.strip('\n') == content
-
     def tearDown(self):
         if os.path.exists(self.testfile):
             os.unlink(self.testfile)
         if self.testfile2 and os.path.exists(self.testfile2):
             os.unlink(self.testfile2)
 
-class TestRst:
-    def setUp(self):
-        self.testfile = "testfile.rst"
 
-    def test_new_normal_usage(self):
-        content = [
-            [1, 2, 3],
-            [4, 588, 6],
-            [7, 8, 999]
-        ]
-        pe.save_as(array=content, dest_file_name=self.testfile)
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
-        content = dedent("""
+class TestRst(TestIO):
+
+    TABLEFMT = 'rst'
+    expected_results = {
+        'normal_usage': dedent("""
+            Sheet Name: pyexcel
+            =  ===  ===
+            1    2    3
+            4  588    6
+            7    8  999
+            =  ===  ===""").strip('\n'),
+        'new_normal_usage_irregular_columns': dedent("""
+            Sheet Name: pyexcel_sheet1
+            =  ===  =
+            1    2  3
+            4  588  6
+            7    8
+            =  ===  =""").strip('\n'),
+        'column_series': dedent("""
+            Sheet Name: pyexcel_sheet1
+            ==========  ==========  ==========
+              Column 1    Column 2    Column 3
+            ==========  ==========  ==========
+                     1           2           3
+                     4           5           6
+                     7           8           9
+            ==========  ==========  ==========""").strip('\n'),
+        'column_series_irregular_columns': dedent("""
+            Sheet Name: pyexcel_sheet1
+            ==========  ==========  ==========
+              Column 1    Column 2  Column 3
+            ==========  ==========  ==========
+                     1           2  3
+                     4           5  6
+                     7           8
+            ==========  ==========  ==========""").strip('\n'),
+        'csvbook_irregular_columns': dedent("""
+            Sheet Name: testfile.csv
+            =  ===  =
+            1    2  3
+            4  588  6
+            7    8
+            =  ===  =""").strip('\n'),
+        'data_frame': dedent("""
+            Sheet Name: pyexcel_sheet1
+            =====  ==========  ==========  ==========
+                     Column 1    Column 2    Column 3
+            =====  ==========  ==========  ==========
+            Row 1           1           2           3
+            Row 2           4           5           6
+            Row 3           7           8           9
+            =====  ==========  ==========  ==========""").strip('\n'),
+        'row_series': dedent("""
+            Sheet Name: pyexcel_sheet1
+            =====  =  =  =
+            Row 1  1  2  3
+            Row 2  4  5  6
+            Row 3  7  8  9
+            =====  =  =  =""").strip('\n'),
+
+    }
+
+    expected_results['new_normal_usage'] = dedent("""
         Sheet Name: pyexcel_sheet1
         =  ===  ===
         1    2    3
         4  588    6
         7    8  999
         =  ===  ===""").strip('\n')
-        assert written_content.strip('\n') == content
 
-    def test_dict(self):
-        adict = {
-            'sheet 1': [[1,2],[3,4]],
-            'sheet 2': [[5,6],[7,8]]
-        }
-        pe.save_book_as(bookdict=adict, dest_file_name=self.testfile)
-        f = open(self.testfile, "r")
-        written_content = f.read()
-        f.close()
-        content = dedent("""
+    expected_results['dict'] = dedent("""
         Sheet Name: sheet 1
         =  =
         1  2
@@ -241,40 +307,134 @@ class TestRst:
         5  6
         7  8
         =  =""").strip('\n')
-        assert written_content.strip('\n') == content
 
-    def tearDown(self):
-        if os.path.exists(self.testfile):
-            os.unlink(self.testfile)
 
-class TestJSON:
-    def setUp(self):
-        self.testfile = "testfile.json"
+class TestHTML(TestIO):
 
-    def test_new_normal_usage(self):
-        content = [
-            [1, 2, 3],
-            [4, 588, 6],
-            [7, 8, 999]
-        ]
-        pe.save_as(array=content, dest_file_name=self.testfile)
+    TABLEFMT = 'html'
+    expected_results = {
+        'dict': dedent("""
+            <html><header><title>testfile.html</title><body>Sheet Name: sheet 1
+            <table>
+            <tr><td style="text-align: right;">1</td><td style="text-align: right;">2</td></tr>
+            <tr><td style="text-align: right;">3</td><td style="text-align: right;">4</td></tr>
+            </table>
+            Sheet Name: sheet 2
+            <table>
+            <tr><td style="text-align: right;">5</td><td style="text-align: right;">6</td></tr>
+            <tr><td style="text-align: right;">7</td><td style="text-align: right;">8</td></tr>
+            </table>
+            </body></html>""").strip('\n'),
+        'normal_usage': dedent("""
+            Sheet Name: pyexcel
+            <table>
+            <tr><td style="text-align: right;">1</td><td style="text-align: right;">  2</td><td style="text-align: right;">  3</td></tr>
+            <tr><td style="text-align: right;">4</td><td style="text-align: right;">588</td><td style="text-align: right;">  6</td></tr>
+            <tr><td style="text-align: right;">7</td><td style="text-align: right;">  8</td><td style="text-align: right;">999</td></tr>
+            </table>""").strip('\n'),
+        'new_normal_usage': dedent("""
+            <html><header><title>testfile.html</title><body>Sheet Name: pyexcel_sheet1
+            <table>
+            <tr><td style="text-align: right;">1</td><td style="text-align: right;">  2</td><td style="text-align: right;">  3</td></tr>
+            <tr><td style="text-align: right;">4</td><td style="text-align: right;">588</td><td style="text-align: right;">  6</td></tr>
+            <tr><td style="text-align: right;">7</td><td style="text-align: right;">  8</td><td style="text-align: right;">999</td></tr>
+            </table>
+            </body></html>""").strip('\n'),
+        'new_normal_usage_irregular_columns': dedent("""
+            <html><header><title>testfile.html</title><body>Sheet Name: pyexcel_sheet1
+            <table>
+            <tr><td style="text-align: right;">1</td><td style="text-align: right;">  2</td><td>3</td></tr>
+            <tr><td style="text-align: right;">4</td><td style="text-align: right;">588</td><td>6</td></tr>
+            <tr><td style="text-align: right;">7</td><td style="text-align: right;">  8</td><td> </td></tr>
+            </table>
+            </body></html>""").strip('\n'),
+        'column_series': dedent("""
+            <html><header><title>testfile.html</title><body>Sheet Name: pyexcel_sheet1
+            <table>
+            <tr><th style="text-align: right;">  Column 1</th><th style="text-align: right;">  Column 2</th><th style="text-align: right;">  Column 3</th></tr>
+            <tr><td style="text-align: right;">         1</td><td style="text-align: right;">         2</td><td style="text-align: right;">         3</td></tr>
+            <tr><td style="text-align: right;">         4</td><td style="text-align: right;">         5</td><td style="text-align: right;">         6</td></tr>
+            <tr><td style="text-align: right;">         7</td><td style="text-align: right;">         8</td><td style="text-align: right;">         9</td></tr>
+            </table>
+            </body></html>""").strip('\n'),
+        'column_series_irregular_columns': dedent("""
+            <html><header><title>testfile.html</title><body>Sheet Name: pyexcel_sheet1
+            <table>
+            <tr><th style="text-align: right;">  Column 1</th><th style="text-align: right;">  Column 2</th><th>Column 3  </th></tr>
+            <tr><td style="text-align: right;">         1</td><td style="text-align: right;">         2</td><td>3         </td></tr>
+            <tr><td style="text-align: right;">         4</td><td style="text-align: right;">         5</td><td>6         </td></tr>
+            <tr><td style="text-align: right;">         7</td><td style="text-align: right;">         8</td><td>          </td></tr>
+            </table>
+            </body></html>""").strip('\n'),
+        'csvbook_irregular_columns': dedent("""
+            <html><header><title>testfile.html</title><body>Sheet Name: testfile.csv
+            <table>
+            <tr><td style="text-align: right;">1</td><td style="text-align: right;">  2</td><td>3</td></tr>
+            <tr><td style="text-align: right;">4</td><td style="text-align: right;">588</td><td>6</td></tr>
+            <tr><td style="text-align: right;">7</td><td style="text-align: right;">  8</td><td> </td></tr>
+            </table>
+            </body></html>""").strip('\n'),
+        'data_frame': dedent("""
+            <html><header><title>testfile.html</title><body>Sheet Name: pyexcel_sheet1
+            <table>
+            <tr><th>     </th><th style="text-align: right;">  Column 1</th><th style="text-align: right;">  Column 2</th><th style="text-align: right;">  Column 3</th></tr>
+            <tr><td>Row 1</td><td style="text-align: right;">         1</td><td style="text-align: right;">         2</td><td style="text-align: right;">         3</td></tr>
+            <tr><td>Row 2</td><td style="text-align: right;">         4</td><td style="text-align: right;">         5</td><td style="text-align: right;">         6</td></tr>
+            <tr><td>Row 3</td><td style="text-align: right;">         7</td><td style="text-align: right;">         8</td><td style="text-align: right;">         9</td></tr>
+            </table>
+            </body></html>""").strip('\n'),
+        'row_series': dedent("""
+            <html><header><title>testfile.html</title><body>Sheet Name: pyexcel_sheet1
+            <table>
+            <tr><td>Row 1</td><td style="text-align: right;">1</td><td style="text-align: right;">2</td><td style="text-align: right;">3</td></tr>
+            <tr><td>Row 2</td><td style="text-align: right;">4</td><td style="text-align: right;">5</td><td style="text-align: right;">6</td></tr>
+            <tr><td>Row 3</td><td style="text-align: right;">7</td><td style="text-align: right;">8</td><td style="text-align: right;">9</td></tr>
+            </table>
+            </body></html>
+            """).strip('\n'),
+    }
+
+
+class TestJSON(TestIO):
+
+    TABLEFMT = 'json'
+    expected_results = {
+        'dict':
+            '{"sheet 1": [[1, 2], [3, 4]], "sheet 2": [[5, 6], [7, 8]]}',
+        'normal_usage':
+            '{"pyexcel": [[1, 2, 3], [4, 588, 6], [7, 8, 999]]}',
+        'new_normal_usage':
+            '[[1, 2, 3], [4, 588, 6], [7, 8, 999]]',
+        'new_normal_usage_irregular_columns':
+            '[[1, 2, 3], [4, 588, 6], [7, 8]]',
+    }
+
+    def _check_test_file(self, name):
         with open(self.testfile, "r") as f:
-            written_content = json.load(f)
-            assert written_content == content
+            json.load(f)
 
-    def test_dict(self):
-        adict = {
-            'sheet 1': [[1,2],[3,4]],
-            'sheet 2': [[5,6],[7,8]]
-        }
-        pe.save_book_as(bookdict=adict, dest_file_name=self.testfile)
-        with open(self.testfile, "r") as f:
-            written_content = json.load(f)
-            assert written_content == adict
+        super(TestJSON, self)._check_test_file(name)
 
-    def tearDown(self):
-        if os.path.exists(self.testfile):
-            os.unlink(self.testfile)
+    # These all raise TypeError: x is not JSON serializable
+    @expectedFailure
+    def test_column_series(self):
+        super(TestJSON, self).test_column_series()
+
+    @expectedFailure
+    def test_column_series_irregular_columns(self):
+        super(TestJSON, self).test_column_series_irregular_columns()
+
+    @expectedFailure
+    def test_csvbook_irregular_columns(self):
+        super(TestJSON, self).test_csvbook_irregular_columns()
+
+    @expectedFailure
+    def test_row_series(self):
+        super(TestJSON, self).test_row_series()
+
+    @expectedFailure
+    def test_data_frame(self):
+        super(TestJSON, self).test_data_frame()
 
 
 class TestStream:
@@ -298,3 +458,6 @@ class TestStream:
             7    8  999
             -  ---  ---""").strip('\n')
         assert written_content == content
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds many tests for html, json, and rst.
Notes many errors for json.

Update JsonSheetWriter to order JSON keys for reproducible
file output checks.
