### PR TITLE
Test different versions of tabulate

### DIFF
--- a/.moban.d/travis.yml
+++ b/.moban.d/travis.yml
@@ -1,5 +1,31 @@
 {% extends "travis.yml.jj2" %}
+{%block extra_matrix %}
+matrix:
+  include:
+    - python: 2.7
+      env: MINREQ=1
 
+    - python: 2.7
+      env: TABULATE_VERSION=dev
+
+    - python: 2.7
+      dist: trusty
+      sudo: required
+      virtualenv:
+        system_site_packages: true
+      addons:
+        apt:
+          sources:
+            - debian-sid
+          packages:
+            - python-tabulate
+            - python-texttable
+            - python-requests
+            - python-coverage
+{%endblock%}
 {%block custom_install%}
-  - pip install https://github.com/pyexcel/pyexcel/archive/v0.2.1.zip
+  - if [[ "$TABULATE_VERSION" = "dev" ]]; then
+      pip install git+https://bitbucket.org/astanin/python-tabulate ;
+      echo > README.rst ;
+    fi
 {%endblock%}

--- a/.moban.yml
+++ b/.moban.yml
@@ -8,7 +8,8 @@ targets:
   - README.rst: README.rst
   - setup.py: setup.py
   - .travis.yml: travis.yml
-  - requirements.txt: requirements.txt
+  - requirements.txt: requirements.txt.jj2
+  - min_requirements.txt: min_requirements.txt.jj2
   - LICENSE: LICENSE.jj2
   - MANIFEST.in: MANIFEST.in.jj2
   - "tests/requirements.txt": "tests/requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,33 @@ python:
   - 3.3
   - 3.4
   - 3.5
+matrix:
+  include:
+    - python: 2.7
+      env: MINREQ=1
+
+    - python: 2.7
+      env: TABULATE_VERSION=dev
+
+    - python: 2.7
+      dist: trusty
+      sudo: required
+      virtualenv:
+        system_site_packages: true
+      addons:
+        apt:
+          sources:
+            - debian-sid
+          packages:
+            - python-tabulate
+            - python-texttable
+            - python-requests
+            - python-coverage
 before_install:
-  - pip install https://github.com/pyexcel/pyexcel/archive/v0.2.1.zip
+  - if [[ "$TABULATE_VERSION" = "dev" ]]; then
+      pip install git+https://bitbucket.org/astanin/python-tabulate ;
+      echo > README.rst ;
+    fi
   - if [[ -f min_requirements.txt && "$MINREQ" -eq 1 ]]; then
       mv min_requirements.txt requirements.txt ;
     fi

--- a/min_requirements.txt
+++ b/min_requirements.txt
@@ -1,0 +1,2 @@
+pyexcel==0.2.2
+tabulate==0.7.4


### PR DESCRIPTION
Add Travis jobs for testing minimum supported versions
and testing against Debian sid packages, specifically
tabulate 0.7.5, which is also included in Ubuntu wily+.

Also restore testing of tabulate 0.7.6dev from #21.
